### PR TITLE
Custom actions

### DIFF
--- a/customer-service/omnichannel/smart-assist-bot/SmartAssistBot/SmartAssist/CustomActions/customactions.js
+++ b/customer-service/omnichannel/smart-assist-bot/SmartAssistBot/SmartAssist/CustomActions/customactions.js
@@ -1,0 +1,27 @@
+﻿/*
+* Custom Action CustomActionSendKB: Posts KB article link to conversation control
+* @params  kblink : KB article Link
+*/
+window.top.CustomActionSendKB = function (params) {
+    return new Promise(function (resolve, reject) {
+        var evt = new CustomEvent("onsendkbarticle", {
+            "detail": {
+                "title": "KB Article",
+                "link": params.kblink
+            }
+        });
+        window.top.dispatchEvent(evt);
+        resolve("Applied!");
+    });
+}
+
+/*
+* Custom Action CustomActionSendKB: Opens up a KB article in a separate browser tab
+* @params  linktoopen : KB article Link 
+*/
+window.top.CustomActionOpenURL = function (params) {
+    return new Promise(function (resolve, reject) {
+        window.open(params.linktoopen);
+        resolve("Applied!");
+    });
+}

--- a/customer-service/omnichannel/smart-assist-bot/SmartAssistBot/SmartAssist/Operations/KBSearchOperation.cs
+++ b/customer-service/omnichannel/smart-assist-bot/SmartAssistBot/SmartAssist/Operations/KBSearchOperation.cs
@@ -115,21 +115,20 @@ namespace CoreBot.SmartAssist.Operations
                     new AdaptiveSubmitAction() {
                         IconUrl = SendIcon,
                         Title = "Send",
-                        Data = new MacroData() {
-                            // This macro should already be configured in the CDS org. Please note that the names are case sensitive
-                            MacroName = "SendKBAsEmail",
-                            MacroParameters = new Dictionary<string, string>() {
-                                ["EmailTemplateName"] = "KBEmaiLTemplate"
+                        Data = new CustomActionData() {
+                            CustomAction = "CustomActionSendKB",
+                            CustomParameters = new Dictionary<string, string>() {
+                                ["kblink"] = WebsiteURL + articleNumber
                             }
                         }
                     },
                     new AdaptiveSubmitAction() {
                         IconUrl = OpenIcon,
                         Title = "Open",
-                        Data = new MacroData() {
-                            MacroName = "OpenKBLink",
-                            MacroParameters = new Dictionary<string, string>() {
-                                ["kblink"] = WebsiteURL + articleNumber
+                        Data = new CustomActionData() {
+                            CustomAction = "CustomActionOpenURL",
+                            CustomParameters = new Dictionary<string, string>() {
+                                ["linktoopen"] = WebsiteURL + articleNumber
                             }
                         }
                     }

--- a/customer-service/omnichannel/smart-assist-bot/SmartAssistBot/appsettings.json
+++ b/customer-service/omnichannel/smart-assist-bot/SmartAssistBot/appsettings.json
@@ -1,10 +1,10 @@
 {
     // LUIS connection settings
     "LuisAPIHostName": "westus.api.cognitive.microsoft.com",
-    "LuisAPIKey": "<LUIS API Key>",
-    "LuisAppId": "<LUIS App Id>",
+    "LuisAPIKey": "", // LUIS App Key
+    "LuisAppId": "", // LUIS App Id
 
-    // Bot settings
+  // Bot settings
     "MicrosoftAppId": "<Microsoft App Id as generated when you created your bot>",
     "MicrosoftAppPassword": "<Microsoft App password as generated when you created your bot>",
     "REMOTEDEBUGGINGVERSION": "15.0.28307.222",


### PR DESCRIPTION
Fix for Bug 1699598: [Smart assist documentation] : Is the code for actions ’send KB’ and ‘Open KB’ included in the sample- if not can we do so?

- Uploaded Sample Custom actions for send and open KB search

 