### PR TITLE
Adding a use case for exporting forecast data in csv format

### DIFF
--- a/sales/ForecastingAPI/ForecastPublicApiUsageDemo/CRM/OrganizationService.cs
+++ b/sales/ForecastingAPI/ForecastPublicApiUsageDemo/CRM/OrganizationService.cs
@@ -1,19 +1,22 @@
 ﻿using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Client;
 using Microsoft.Xrm.Sdk.Query;
 using Microsoft.Xrm.Tooling.Connector;
 using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ForecastPublicApiUsageDemo.CRM
 {
     class OrganizationService
     {
-        private static string TIP_CONN_STR_TEMP = "AuthType=Office365;Username={0};Password={1};Url={2};AppId=57b7286c-58c7-49be-aaa7-157ea9dfb8b9;RedirectUri=api://57b7286c-58c7-49be-aaa7-157ea9dfb8b9;TokenCacheStorePath=c:\\MyTokenCache;LoginPrompt=Never";
+        private const string TIP_CONN_STR_TEMP = @"
+                AuthType = OAuth;
+                UserName = {0};
+                Password = {1};
+                Url = {2};
+                AppId = 51f81489-12ee-4a9e-aaae-a2591f45987d;
+                RedirectUri = app://58145B91-0C36-4500-8554-080854F2AC97;
+                LoginPrompt=Auto;
+                RequireNewInstance = True";
 
         /// <summary>
         /// Create the organization service for using Public APIs endpoints
@@ -40,12 +43,11 @@ namespace ForecastPublicApiUsageDemo.CRM
         {
             LogWriter.GetLogWriter().LogWrite("Connecting to CRM org");
             CrmServiceClient crmConn = new CrmServiceClient(connstr);
-            OrganizationServiceProxy crmService = crmConn.OrganizationServiceProxy;
-            if (crmService != null)
+            if (crmConn.IsReady)
                 LogWriter.GetLogWriter().LogWrite("Connection successful");
             else
                 LogWriter.GetLogWriter().LogWrite("Connection failed");
-            return crmService;
+            return crmConn;
 
         }
 

--- a/sales/ForecastingAPI/ForecastPublicApiUsageDemo/ForecastPublicApiUsageDemo.csproj
+++ b/sales/ForecastingAPI/ForecastPublicApiUsageDemo/ForecastPublicApiUsageDemo.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\Constants.cs" />
     <Compile Include="Utility\UpdateSimpleColumnStatusCode.cs" />
+    <Compile Include="Utility\UsecaseHelper.cs" />
     <Compile Include="Utility\UtilityImpl.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/Constants.cs
+++ b/sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/Constants.cs
@@ -20,8 +20,8 @@ namespace ForecastPublicApiUsageDemo.Utility
 
 
         // Usecase related Constants
-        public const string forecastConfigurationName = "acc-5k-1";
-        public const string forecastperiodName = "FY2020 Q2";
+        public const string forecastConfigurationName = "Sample Forecast";
+        public const string forecastperiodName = "FY{0} {1}"; //E.g. FY2024 May
 
 
     }

--- a/sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/UsecaseHelper.cs
+++ b/sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/UsecaseHelper.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Dynamics.Forecasting.Common.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ForecastPublicApiUsageDemo.Utility
+{
+    static class UsecaseHelper
+    {
+        public static void CreateCSVOfForecastInstances(ForecastConfiguration forecastConfiguration, List<ForecastInstance> forecastInstances)
+        {
+            LogWriter.GetLogWriter().LogWrite("Creating CSV for the FC and Aggregated Columns.");
+            // Get all the columns from the forecast configuration
+            List<ForecastConfigurationColumn> columns = forecastConfiguration.Columns;
+
+            // Create the header row with the hierarchy record and names of the columns
+            string headerRow = CreateHeaderRow(columns);
+
+            // Create the data rows
+            string dataRows = CreateDataRows(columns, forecastInstances);
+
+            var csvContent = headerRow + dataRows;
+
+            // Save the CSV file in local disk
+            const string fileName = "Path.csv";
+            File.WriteAllText(fileName, csvContent);
+
+            LogWriter.GetLogWriter().LogWrite("Created CSV for the FC and Aggregated Columns.");
+        }
+
+        private static string CreateHeaderRow(List<ForecastConfigurationColumn> columns)
+        {
+            return "HierarchyRecordId," + string.Join(",", columns.Select(c => c.DisplayName).ToArray()) + "\n";
+        }
+
+        private static string CreateDataRows(List<ForecastConfigurationColumn> columns, List<ForecastInstance> forecastInstances)
+        {
+            string dataRows = "";
+            foreach (ForecastInstance forecastInstance in forecastInstances)
+            {
+                var fiColumns = GetForecastInstanceColumns(forecastInstance);
+                Guid recordId = forecastInstance.HierarchyEntityRecord.RecordId;
+                string columnData = string.Join(",", columns.Select(c => GetColumnValue(c, fiColumns)).ToArray());
+                dataRows += $"{recordId},{columnData}\n";
+            }
+
+            return dataRows;
+        }
+
+        private static string GetColumnValue(ForecastConfigurationColumn column, Dictionary<Guid, string> fiColumns)
+        {
+            return fiColumns.ContainsKey(column.ForecastConfigurationColumnId) ? fiColumns[column.ForecastConfigurationColumnId] : "";
+        }
+
+        private static Dictionary<Guid, string> GetForecastInstanceColumns(ForecastInstance forecastInstance)
+        {
+            return forecastInstance.AggregatedColumns.ToDictionary(c => c.ForecastConfigurationColumnId, c => string.IsNullOrEmpty(c.DisplayValue) ? c.Value.ToString() : c.DisplayValue);
+        }
+    }
+}

--- a/sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/UtilityImpl.cs
+++ b/sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/UtilityImpl.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ForecastPublicApiUsageDemo.Utility
 {
@@ -19,9 +17,11 @@ namespace ForecastPublicApiUsageDemo.Utility
                 dataSet.TryGetValue(forecastInstance.HierarchyEntityRecord.RecordId, out value);
                 if (value != forecastInstance.AggregatedColumns[1].Value)
                 {
-                    LogWriter.GetLogWriter().LogWrite($"FI Value does not match {forecastInstance.ForecastInstanceId} {value} { forecastInstance.AggregatedColumns[1].Value}");
+                    LogWriter.GetLogWriter().LogWrite($"FI Value does not match {forecastInstance.ForecastInstanceId} {value} {forecastInstance.AggregatedColumns[1].Value}");
                 }
             }
+
+            LogWriter.GetLogWriter().LogWrite("Verified data set.");
         }
 
         public static string DictToDebugString<TKey, TValue>(Dictionary<TKey, TValue> dictionary)
@@ -36,7 +36,7 @@ namespace ForecastPublicApiUsageDemo.Utility
             return random.NextDouble() * (maximum - minimum) + minimum;
         }
 
-        public static Dictionary<Guid, Double> prepareDataSet(List<ForecastInstance> forecastInstances)
+        public static Dictionary<Guid, Double> PrepareDataSet(List<ForecastInstance> forecastInstances)
         {
             Dictionary<Guid, Double> dataSet = new Dictionary<Guid, double>();
             double minimum = 1000;
@@ -51,6 +51,5 @@ namespace ForecastPublicApiUsageDemo.Utility
             }
             return dataSet;
         }
-
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `ForecastPublicApiUsageDemo` in the `sales/ForecastingAPI` directory. The changes primarily focus on improving the organization of the code, enhancing the connection to the CRM service, and adding new functionality for creating a CSV of forecast instances.

Connection and organization improvements:

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/CRM/OrganizationService.cs`](diffhunk://#diff-be8e4b7d91ea6dc90a8a2c42a55d55cd7640b4b2a478ce8ccfb87d7eeb2f101fL2-R19): The connection string template `TIP_CONN_STR_TEMP` was updated to use OAuth and require a new instance. The method `getOrgService` was simplified to return `crmConn` directly if the connection is ready, instead of using `crmService`. [[1]](diffhunk://#diff-be8e4b7d91ea6dc90a8a2c42a55d55cd7640b4b2a478ce8ccfb87d7eeb2f101fL2-R19) [[2]](diffhunk://#diff-be8e4b7d91ea6dc90a8a2c42a55d55cd7640b4b2a478ce8ccfb87d7eeb2f101fL43-R50)

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/Program.cs`](diffhunk://#diff-79877895734a342d3bdaa92e9ce0973d77bfc2bc462f290d03f8640a7058d1a6R51-R54): Variable names were updated to be more descriptive, and the `PerformUsecase` method now uses dynamic forecast configuration and period names. [[1]](diffhunk://#diff-79877895734a342d3bdaa92e9ce0973d77bfc2bc462f290d03f8640a7058d1a6R51-R54) [[2]](diffhunk://#diff-79877895734a342d3bdaa92e9ce0973d77bfc2bc462f290d03f8640a7058d1a6L63-R97)

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/Constants.cs`](diffhunk://#diff-b2f5d9bb8c235ffca6f0d54d45023b116a4799e3221965f91f76fcce1d4f397dL23-R24): The constants for `forecastConfigurationName` and `forecastperiodName` were updated to be more generic.

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/UtilityImpl.cs`](diffhunk://#diff-a2b39cbb3f7bbaed3324efe16b17d4790247e134416849e16a4ef55fd58df8aeR23-R24): The `VerifyDataSet` method now logs a message after verification, and the `prepareDataSet` method was renamed to `PrepareDataSet` to follow C# naming conventions. [[1]](diffhunk://#diff-a2b39cbb3f7bbaed3324efe16b17d4790247e134416849e16a4ef55fd58df8aeR23-R24) [[2]](diffhunk://#diff-a2b39cbb3f7bbaed3324efe16b17d4790247e134416849e16a4ef55fd58df8aeL39-R39)

New functionality:

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/ForecastPublicApiUsageDemo.csproj`](diffhunk://#diff-ba2f03d3abd95fa51bb2f6a89c2537a3a4f1dc74c01846efa87b2d48708b44e4R145): A new file `UsecaseHelper.cs` was added to the project.

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/Utility/UsecaseHelper.cs`](diffhunk://#diff-820fc516de45b8056a5f95bef1a4c9ff5647171a947023faef5a6f5d6a14cf72R1-R61): This new file includes a static class `UsecaseHelper` with methods to create a CSV of forecast instances.

* [`sales/ForecastingAPI/ForecastPublicApiUsageDemo/Program.cs`](diffhunk://#diff-79877895734a342d3bdaa92e9ce0973d77bfc2bc462f290d03f8640a7058d1a6L63-R97): The `PerformUsecase` method now calls `UsecaseHelper.CreateCSVOfForecastInstances` to create a CSV of forecast instances.